### PR TITLE
ci(bench): fix CORE-MATH path, add fma benchmarks, fix GitHub Pages

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,11 +34,20 @@ jobs:
       # the source headers, not the full history.
       - name: Clone CORE-MATH
         run: |
+          # Clone to the parent of the src/ directory so that the default
+          # CORE_MATH ?= $(HOME)/src/core-math-sys/vendor/src in the Makefile
+          # resolves to the src/ subdirectory inside the CORE-MATH repo root,
+          # where binary32/<func>/<funcf>.c lives.
           git clone --depth=1 https://gitlab.inria.fr/core-math/core-math.git \
-            "${HOME}/src/core-math-sys/vendor/src"
+            "${HOME}/src/core-math-sys/vendor"
 
       - name: Build metallic.a
         run: make metallic.a
+
+      # bench.fma: Metallic vs CORE-MATH vs libm for the 19 correctly-rounded
+      # float unary functions compiled with -march=native (hardware FMA enabled).
+      - name: Run fma benchmarks
+        run: make bench.fma 2>&1 | tee bench_fma.txt
 
       # bench.nofma: Metallic vs CORE-MATH vs libm for the 19 correctly-rounded
       # float unary functions, with -ffp-contract=off -mno-fma to match the
@@ -57,7 +66,7 @@ jobs:
 
       - name: Parse benchmark output to JSON
         run: |
-          cat bench_nofma.txt bench_libm.txt \
+          cat bench_fma.txt bench_nofma.txt bench_libm.txt \
             | python3 scripts/parse_bench.py > bench.json
           cat bench.json
 


### PR DESCRIPTION
Three fixes for the benchmark CI:

1. CORE-MATH clone path was wrong: the repo was cloned to
   vendor/src (making CORE_MATH equal to the repo root), but
   CORE-MATH's sources live under src/binary32/ inside the
   repo.  Clone to vendor instead so the Makefile default
   CORE_MATH ?= $(HOME)/src/core-math-sys/vendor/src correctly
   resolves to the src/ subdirectory that contains binary32/.

2. Add the missing "Run fma benchmarks" step (make bench.fma),
   which benchmarks the 19 CR float functions with -march=native
   (hardware FMA) for comparison with the no-FMA WASM results.

3. Include bench_fma.txt in the parse step so [fma] data points
   appear in the published GitHub Pages charts alongside [nofma].
   The GitHub Pages publish step was failing as a cascade from (1)
   since the nofma step never produced valid JSON.

https://claude.ai/code/session_0183V437dyjxNyKeGEGcwUZ9